### PR TITLE
Fix links to empty files

### DIFF
--- a/data/builder/directory.go
+++ b/data/builder/directory.go
@@ -77,6 +77,8 @@ func estimateDirSize(entries []dagpb.PBLink) int {
 		cl, ok := lnk.(cidlink.Link)
 		if ok {
 			s += cl.ByteLen()
+		} else if lnk == nil {
+			s += 0
 		} else {
 			s += len(lnk.Binary())
 		}

--- a/data/builder/file.go
+++ b/data/builder/file.go
@@ -43,6 +43,11 @@ func BuildUnixFSFile(r io.Reader, chunker string, ls *ipld.LinkSystem) (ipld.Lin
 		}
 
 		if prev != nil && prev[0] == root {
+			if root == nil {
+				node := basicnode.NewBytes([]byte{})
+				link, err := ls.Store(ipld.LinkContext{}, leafLinkProto, node)
+				return link, 0, err
+			}
 			return root, size, nil
 		}
 


### PR DESCRIPTION
previously the link in the directory would be nil. instead it should be the cid for an empty bytes node.