### PR TITLE
Fix `Tsize` values, fix HAMT and make recursive builder output match go-unixfs

### DIFF
--- a/data/builder/dir_test.go
+++ b/data/builder/dir_test.go
@@ -3,12 +3,16 @@ package builder
 import (
 	"bytes"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-unixfsnode"
 	dagpb "github.com/ipld/go-codec-dagpb"
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/stretchr/testify/require"
 )
 
 func mkEntries(cnt int, ls *ipld.LinkSystem) ([]dagpb.PBLink, error) {
@@ -41,10 +45,12 @@ func TestBuildUnixFSDirectory(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		dl, err := BuildUnixFSDirectory(entries, &ls)
+		dl, tsize, err := BuildUnixFSDirectory(entries, &ls)
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		require.GreaterOrEqual(t, tsize, uint64(0)) // TODO: set properly
 
 		pbn, err := ls.Load(ipld.LinkContext{}, dl, dagpb.Type.PBNode)
 		if err != nil {
@@ -69,4 +75,66 @@ func TestBuildUnixFSDirectory(t *testing.T) {
 			t.Fatalf("unexpected number of dir entries %d vs %d", observedCnt, cnt)
 		}
 	}
+}
+
+func TestBuildUnixFSRecursive(t *testing.T) {
+	// only the top CID is of interest, but this tree is correct and can be used for future validation
+	fixture := fentry{
+		"rootDir",
+		"",
+		mustCidDecode("bafybeihswl3f7pa7fueyayewcvr3clkdz7oetv4jolyejgw26p6l3qzlbm"),
+		[]fentry{
+			{"a", "aaa", mustCidDecode("bafkreieygsdw3t5qlsywpjocjfj6xjmmjlejwgw7k7zi6l45bgxra7xi6a"), nil},
+			{
+				"b",
+				"",
+				mustCidDecode("bafybeibohj54uixf2mso4t53suyarv6cfuxt6b5cj6qjsqaa2ezfxnu5pu"),
+				[]fentry{
+					{"1", "111", mustCidDecode("bafkreihw4cq6flcbsrnjvj77rkfkudhlyevdxteydkjjvvopqefasdqrvy"), nil},
+					{"2", "222", mustCidDecode("bafkreie3q4kremt4bhhjdxletm7znjr3oqeo6jt4rtcxcaiu4yuxgdfwd4"), nil},
+				},
+			},
+			{"c", "ccc", mustCidDecode("bafkreide3ksevvet74uks3x7vnxhp4ltfi6zpwbsifmbwn6324fhusia7y"), nil},
+		},
+	}
+
+	ls := cidlink.DefaultLinkSystem()
+	storage := cidlink.Memory{}
+	ls.StorageReadOpener = storage.OpenRead
+	ls.StorageWriteOpener = storage.OpenWrite
+
+	dir := t.TempDir()
+	makeFixture(t, dir, fixture)
+
+	lnk, sz, err := BuildUnixFSRecursive(filepath.Join(dir, fixture.name), &ls)
+	require.NoError(t, err)
+	require.Equal(t, lnk.String(), fixture.expectedLnk.String())
+	require.Equal(t, sz, uint64(245))
+}
+
+type fentry struct {
+	name        string
+	content     string
+	expectedLnk cid.Cid
+	children    []fentry
+}
+
+func makeFixture(t *testing.T, dir string, fixture fentry) {
+	path := filepath.Join(dir, fixture.name)
+	if fixture.children != nil {
+		require.NoError(t, os.Mkdir(path, 0755))
+		for _, c := range fixture.children {
+			makeFixture(t, path, c)
+		}
+	} else {
+		os.WriteFile(path, []byte(fixture.content), 0644)
+	}
+}
+
+func mustCidDecode(s string) cid.Cid {
+	c, err := cid.Decode(s)
+	if err != nil {
+		panic(err)
+	}
+	return c
 }

--- a/data/builder/util.go
+++ b/data/builder/util.go
@@ -2,7 +2,12 @@ package builder
 
 import (
 	"fmt"
+	"io"
 	"math/bits"
+
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/codec"
+	"github.com/ipld/go-ipld-prime/datamodel"
 )
 
 // Common code from go-unixfs/hamt/util.go
@@ -53,4 +58,52 @@ func logtwo(v int) (int, error) {
 		return 0, fmt.Errorf("hamt size should be a power of two")
 	}
 	return lg2, nil
+}
+
+func sizedStore(ls *ipld.LinkSystem, lp datamodel.LinkPrototype, n datamodel.Node) (datamodel.Link, uint64, error) {
+	var byteCount int
+	lnk, err := wrappedLinkSystem(ls, func(bc int) {
+		byteCount = bc
+	}).Store(ipld.LinkContext{}, lp, n)
+	return lnk, uint64(byteCount), err
+}
+
+type byteCounter struct {
+	w  io.Writer
+	bc int
+}
+
+func (bc *byteCounter) Write(p []byte) (int, error) {
+	bc.bc += len(p)
+	return bc.w.Write(p)
+}
+
+func wrappedLinkSystem(ls *ipld.LinkSystem, byteCountCb func(byteCount int)) *ipld.LinkSystem {
+	wrappedEncoder := func(encoder codec.Encoder) codec.Encoder {
+		return func(node datamodel.Node, writer io.Writer) error {
+			bc := byteCounter{w: writer}
+			err := encoder(node, &bc)
+			if err == nil {
+				byteCountCb(bc.bc)
+			}
+			return err
+		}
+	}
+	wrappedEncoderChooser := func(lp datamodel.LinkPrototype) (codec.Encoder, error) {
+		encoder, err := ls.EncoderChooser(lp)
+		if err != nil {
+			return nil, err
+		}
+		return wrappedEncoder(encoder), nil
+	}
+	return &ipld.LinkSystem{
+		EncoderChooser:     wrappedEncoderChooser,
+		DecoderChooser:     ls.DecoderChooser,
+		HasherChooser:      ls.HasherChooser,
+		StorageWriteOpener: ls.StorageWriteOpener,
+		StorageReadOpener:  ls.StorageReadOpener,
+		TrustedStorage:     ls.TrustedStorage,
+		NodeReifier:        ls.NodeReifier,
+		KnownReifiers:      ls.KnownReifiers,
+	}
 }


### PR DESCRIPTION
OK, this started as something _entirely_ different, I'll get to that in another PR later. But while using this I noticed that `Tsize` isn't getting set properly on directories. Then while fixing that, I noticed that the HAMT doesn't quite work properly, so I fixed that.

There's two main tests in here, one for a smaller directory structure and one for a very large one that breaks out the sharding. I've generated the CIDs from go-ipfs by `ipfs add`ing them. (and final Tsize values calculated by looking at link sizes in root blocks and adding the root block size to the total: `ipfs dag get bafybei... | jq '[.Links[].Tsize | tonumber] | add'` & `ipfs block get bafybei... | wc -c`).

It's a breaking change because all of the builder `BuildX()` functions return `datamodel.Link, unit64, error` now so the size is included (mainly because it needs to be for recursive internal collection, but the reported size is an accurate representation of the structure's _weight_ so should be useful in some situations too).

While in here, I replaced the block size calculation hack (load saved block as raw and use byte length) with a new, even more exotic hack, to count the bytes as they are pushed out of the encoder by wrapping the LinkSystem, EncoderChooser and Encoder at each save point. Not trivial, but saves the round-trip out of the block store. @warpfork @mvdan I think the need for block size at the `Store()` call for well formed dag-pb graphs makes a pretty strong case that this should be easier to retrieve out of the API—perhaps just `Store()` should return 3 values?