### PR TITLE
relaxed reification

### DIFF
--- a/reification.go
+++ b/reification.go
@@ -17,7 +17,12 @@ import (
 func Reify(lnkCtx ipld.LinkContext, maybePBNodeRoot ipld.Node, lsys *ipld.LinkSystem) (ipld.Node, error) {
 	pbNode, ok := maybePBNodeRoot.(dagpb.PBNode)
 	if !ok {
-		return maybePBNodeRoot, nil
+		// see if the node has the right structure anyway
+		pbb := dagpb.Type.PBNode.NewBuilder()
+		if err := pbb.AssignNode(maybePBNodeRoot); err != nil {
+			return maybePBNodeRoot, nil
+		}
+		pbNode = pbb.Build().(dagpb.PBNode)
 	}
 	if !pbNode.FieldData().Exists() {
 		// no data field, therefore, not UnixFS


### PR DESCRIPTION
If a node is not an immediate pbnode, but can be built as such, then reifiy appropriately.

This allows a dag-pb node to have been serialized to cbor or json, and still be interpreted as unixfs data.