### PR TITLE
Add unixfs to UnixFS path selector tail

### DIFF
--- a/signaling.go
+++ b/signaling.go
@@ -22,7 +22,7 @@ func AddUnixFSReificationToLinkSystem(lsys *ipld.LinkSystem) {
 func UnixFSPathSelector(path string) datamodel.Node {
 	segments := strings.Split(path, "/")
 	ssb := builder.NewSelectorSpecBuilder(basicnode.Prototype.Any)
-	selectorSoFar := ssb.Matcher()
+	selectorSoFar := ssb.ExploreInterpretAs("unixfs", ssb.Matcher())
 	for i := len(segments) - 1; i >= 0; i-- {
 		selectorSoFar = ssb.ExploreInterpretAs("unixfs",
 			ssb.ExploreFields(func(efsb builder.ExploreFieldsSpecBuilder) {


### PR DESCRIPTION
# Goals

At the end of pathing into a UnixFS directory, you encounter a UnixFS object (whether file, directory, symlink, etc). You almost always want to reify that node, rather than work with the base protobuf type. This has no effect on single block unixfs files, but for multiblock files and directories, this is the only way you can work with the resulting object properly for the visitor function.

# Implementation

fix the selector for paths, wrapping the last matcher node in an ExploreInterpretAs, since the tail
end of a path into a unixfs dir is itself a unixfsnode