### PR TITLE
add helper to approximate test creation patter from ipfs-files

### DIFF
--- a/data/builder/quick/quick.go
+++ b/data/builder/quick/quick.go
@@ -1,0 +1,77 @@
+// Package quickbuilder is designed as a replacement for the existing ipfs-files
+// constructor for a simple way to generate synthetic directory trees.
+package quickbuilder
+
+import (
+	"bytes"
+
+	"github.com/ipfs/go-unixfsnode/data/builder"
+	dagpb "github.com/ipld/go-codec-dagpb"
+	"github.com/ipld/go-ipld-prime"
+)
+
+// A Node represents the most basic form of a file or directory
+type Node interface {
+	Size() (int64, error)
+	Link() ipld.Link
+}
+
+type lnkNode struct {
+	link ipld.Link
+	size int64
+	ls   *ipld.LinkSystem
+}
+
+func (ln *lnkNode) Size() (int64, error) {
+	return ln.size, nil
+}
+
+func (ln *lnkNode) Link() ipld.Link {
+	return ln.link
+}
+
+// Builder provides the linksystem context for saving files & directories
+type Builder struct {
+	ls *ipld.LinkSystem
+}
+
+// NewMapDirectory creates a unixfs directory from a list of named entries
+func (b *Builder) NewMapDirectory(entries map[string]Node) Node {
+	lnks := make([]dagpb.PBLink, 0, len(entries))
+	for name, e := range entries {
+		sz, _ := e.Size()
+		entry, err := builder.BuildUnixFSDirectoryEntry(name, sz, e.Link())
+		if err != nil {
+			return nil
+		}
+		lnks = append(lnks, entry)
+	}
+	n, size, err := builder.BuildUnixFSDirectory(lnks, b.ls)
+	if err != nil {
+		panic(err)
+	}
+	return &lnkNode{
+		n,
+		int64(size),
+		b.ls,
+	}
+}
+
+// NewBytesFile creates a unixfs file from byte contents
+func (b *Builder) NewBytesFile(data []byte) Node {
+	n, size, err := builder.BuildUnixFSFile(bytes.NewReader(data), "", b.ls)
+	if err != nil {
+		panic(err)
+	}
+	return &lnkNode{
+		n,
+		int64(size),
+		b.ls,
+	}
+}
+
+// Store provides a builder context for making unixfs files and directories
+func Store(ls *ipld.LinkSystem, cb func(b *Builder) error) error {
+	b := Builder{ls}
+	return cb(&b)
+}

--- a/data/builder/quick/quick_test.go
+++ b/data/builder/quick/quick_test.go
@@ -1,0 +1,35 @@
+package quickbuilder_test
+
+import (
+	"testing"
+
+	quickbuilder "github.com/ipfs/go-unixfsnode/data/builder/quick"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/ipld/go-ipld-prime/storage/memstore"
+)
+
+func TestQuickBuilder(t *testing.T) {
+	ls := cidlink.DefaultLinkSystem()
+	store := memstore.Store{Bag: make(map[string][]byte)}
+	ls.SetReadStorage(&store)
+	ls.SetWriteStorage(&store)
+	err := quickbuilder.Store(&ls, func(b *quickbuilder.Builder) error {
+		b.NewMapDirectory(map[string]quickbuilder.Node{
+			"file.txt": b.NewBytesFile([]byte("1")),
+			"foo? #<'": b.NewMapDirectory(map[string]quickbuilder.Node{
+				"file.txt": b.NewBytesFile([]byte("2")),
+				"bar": b.NewMapDirectory(map[string]quickbuilder.Node{
+					"file.txt": b.NewBytesFile([]byte("3")),
+				}),
+			}),
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(store.Bag) != 6 {
+		t.Fatal("unexpected number of stored nodes")
+	}
+}


### PR DESCRIPTION
There are common in-memory creations of small unixfs directory trees. This provides an easily portable API to do the same with the new ipld-prime linksystem / unixfsnode creation tools.