### PR TITLE
add an ADL to preload hamt loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@ This is an IPLD ADL that provides string based pathing for protobuf nodes. The t
 
 Note that while it works internally with go-codec-dagpb, the Reify method (used to get a UnixFSNode from a DagPB node should actually work successfully with go-ipld-prime-proto nodes)
 
+## Usage
+
+The primary interaction with this package is to register an ADL on a link system. This is done with via a helper method.
+
+```go
+AddUnixFSReificationToLinkSystem(lsys *ipld.LinkSystem)
+```
+
+For link systems which have UnixFS reification registered, two ADLs will be available to the [`InterpretAs`](https://ipld.io/specs/selectors/) selector: 'unixfs' and 'unixfs-preload'. The different between these two ADLs is that the preload variant will access all blocks within a UnixFS Object (file or directory) when that object is accessed by a selector traversal. The non-preload variant in contrast will only access the subset of blocks strictly needed for the traversal. In practice, this means the subset of a sharded directory needed to access a specific file, or the sub-range of a file directly accessed by a range selector.
+
+
 ## License
 
 Apache-2.0/MIT © Protocol Labs

--- a/file/file.go
+++ b/file/file.go
@@ -33,6 +33,21 @@ func NewUnixFSFile(ctx context.Context, substrate ipld.Node, lsys *ipld.LinkSyst
 	}, nil
 }
 
+func NewUnixFSFileWithPreload(ctx context.Context, substrate ipld.Node, lsys *ipld.LinkSystem) (LargeBytesNode, error) {
+	f, err := NewUnixFSFile(ctx, substrate, lsys)
+	if err != nil {
+		return nil, err
+	}
+	r, err := f.AsLargeBytes()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := io.Copy(io.Discard, r); err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
 // A LargeBytesNode is an ipld.Node that can be streamed over. It is guaranteed to have a Bytes type.
 type LargeBytesNode interface {
 	ipld.Node

--- a/file/file.go
+++ b/file/file.go
@@ -33,6 +33,10 @@ func NewUnixFSFile(ctx context.Context, substrate ipld.Node, lsys *ipld.LinkSyst
 	}, nil
 }
 
+// NewUnixFSFileWithPreload is the same as NewUnixFSFile but it performs a full load of constituent
+// blocks where the file spans multiple blocks. This is useful where a system needs to watch the
+// LinkSystem for block loads to determine which blocks make up this file.
+// NewUnixFSFileWithPreload is used by the "unixfs-preload" reifier.
 func NewUnixFSFileWithPreload(ctx context.Context, substrate ipld.Node, lsys *ipld.LinkSystem) (LargeBytesNode, error) {
 	f, err := NewUnixFSFile(ctx, substrate, lsys)
 	if err != nil {

--- a/hamt/shardeddir.go
+++ b/hamt/shardeddir.go
@@ -54,6 +54,22 @@ func NewUnixFSHAMTShard(ctx context.Context, substrate dagpb.PBNode, data data.U
 	}, nil
 }
 
+// NewUnixFSHAMTShardWithPreload attempts to construct a UnixFSHAMTShard node from the base protobuf node plus
+// a decoded UnixFSData structure, and then iterate through and load the full set of hamt shards.
+func NewUnixFSHAMTShardWithPreload(ctx context.Context, substrate dagpb.PBNode, data data.UnixFSData, lsys *ipld.LinkSystem) (ipld.Node, error) {
+	n, err := NewUnixFSHAMTShard(ctx, substrate, data, lsys)
+	if err != nil {
+		return n, err
+	}
+
+	traverse := n.Length()
+	if traverse == -1 {
+		return n, fmt.Errorf("could not fully explore hamt during preload")
+	}
+
+	return n, nil
+}
+
 func (n UnixFSHAMTShard) Substrate() ipld.Node {
 	return n._substrate
 }

--- a/signaling.go
+++ b/signaling.go
@@ -15,6 +15,7 @@ func AddUnixFSReificationToLinkSystem(lsys *ipld.LinkSystem) {
 		lsys.KnownReifiers = make(map[string]linking.NodeReifier)
 	}
 	lsys.KnownReifiers["unixfs"] = Reify
+	lsys.KnownReifiers["unixfs-preload"] = nonLazyReify
 }
 
 // UnixFSPathSelector creates a selector for a file/path inside of a UnixFS directory


### PR DESCRIPTION
fix #37

this adds a `unixfs-preload` adl name, which will fully traverse sharded directories and files when encountered.