### PR TITLE
fix a possible `index out of range` crash

### DIFF
--- a/data/builder/file.go
+++ b/data/builder/file.go
@@ -109,6 +109,7 @@ func fileTreeRecursive(depth int, children []ipld.Link, childLen []uint64, src c
 		}
 		totalSize += sz
 		children = append(children, nxt)
+		childLen = append(childLen, sz)
 		blksizes = append(blksizes, sz)
 	}
 	if len(children) == 0 {


### PR DESCRIPTION
I met an `index out of range` crash and try to fix it.
<img width="1246" alt="Screen Shot 2023-01-09 at 17 48 27" src="https://user-images.githubusercontent.com/321962/211282199-90e8306e-af5c-4a5a-9555-224eb3e8fe0d.png">
