### PR TITLE
fix: propagate iteration errors

### DIFF
--- a/directory/basicdir.go
+++ b/directory/basicdir.go
@@ -59,7 +59,7 @@ func (n UnixFSBasicDir) LookupBySegment(seg ipld.PathSegment) (ipld.Node, error)
 }
 
 func (n UnixFSBasicDir) MapIterator() ipld.MapIterator {
-	return iter.NewUnixFSDirMapIterator(n._substrate.Links.Iterator(), nil)
+	return iter.NewUnixFSDirMapIterator(&_UnixFSBasicDir__ListItr{n._substrate.Links.Iterator()}, nil)
 }
 
 // ListIterator returns an iterator which yields key-value pairs
@@ -129,8 +129,7 @@ func (n UnixFSBasicDir) Representation() ipld.Node {
 // Native map accessors
 
 func (n UnixFSBasicDir) Iterator() *iter.UnixFSDir__Itr {
-
-	return iter.NewUnixFSDirIterator(n._substrate.Links.Iterator(), nil)
+	return iter.NewUnixFSDirIterator(&_UnixFSBasicDir__ListItr{n._substrate.Links.Iterator()}, nil)
 }
 
 func (n UnixFSBasicDir) Lookup(key dagpb.String) dagpb.Link {
@@ -150,4 +149,17 @@ func (n UnixFSBasicDir) FieldData() dagpb.MaybeBytes {
 // Substrate returns the underlying PBNode -- note: only the substrate will encode successfully to protobuf if writing
 func (n UnixFSBasicDir) Substrate() ipld.Node {
 	return n._substrate
+}
+
+type _UnixFSBasicDir__ListItr struct {
+	_substrate *dagpb.PBLinks__Itr
+}
+
+func (itr *_UnixFSBasicDir__ListItr) Next() (int64, dagpb.PBLink, error) {
+	idx, v := itr._substrate.Next()
+	return idx, v, nil
+}
+
+func (itr *_UnixFSBasicDir__ListItr) Done() bool {
+	return itr._substrate.Done()
 }

--- a/iter/iter.go
+++ b/iter/iter.go
@@ -5,9 +5,9 @@ import (
 	"github.com/ipld/go-ipld-prime"
 )
 
-// PBLinkItr behaves like an list of links iterator, even thought he HAMT behavior is more complicated
+// PBLinkItr behaves like an list of links iterator, even thought the HAMT behavior is more complicated
 type PBLinkItr interface {
-	Next() (int64, dagpb.PBLink)
+	Next() (int64, dagpb.PBLink, error)
 	Done() bool
 }
 
@@ -25,7 +25,10 @@ type UnixFSDir__MapItr struct {
 }
 
 func (itr *UnixFSDir__MapItr) Next() (k ipld.Node, v ipld.Node, err error) {
-	_, next := itr._substrate.Next()
+	_, next, err := itr._substrate.Next()
+	if err != nil {
+		return nil, nil, err
+	}
 	if next == nil {
 		return nil, nil, ipld.ErrIteratorOverread{}
 	}
@@ -58,7 +61,10 @@ func NewUnixFSDirIterator(itr PBLinkItr, transformName TransformNameFunc) *UnixF
 	return &UnixFSDir__Itr{itr, transformName}
 }
 func (itr *UnixFSDir__Itr) Next() (k dagpb.String, v dagpb.Link) {
-	_, next := itr._substrate.Next()
+	_, next, err := itr._substrate.Next()
+	if err != nil {
+		return nil, nil
+	}
 	if next == nil {
 		return nil, nil
 	}
@@ -70,7 +76,7 @@ func (itr *UnixFSDir__Itr) Next() (k dagpb.String, v dagpb.Link) {
 		return name, next.FieldHash()
 	}
 	nb := dagpb.Type.String.NewBuilder()
-	err := nb.AssignString("")
+	err = nb.AssignString("")
 	if err != nil {
 		return nil, nil
 	}

--- a/iter/iter.go
+++ b/iter/iter.go
@@ -5,22 +5,22 @@ import (
 	"github.com/ipld/go-ipld-prime"
 )
 
-// PBLinkItr behaves like an list of links iterator, even thought the HAMT behavior is more complicated
-type PBLinkItr interface {
+// pbLinkItr behaves like an list of links iterator, even thought the HAMT behavior is more complicated
+type pbLinkItr interface {
 	Next() (int64, dagpb.PBLink, error)
 	Done() bool
 }
 
 type TransformNameFunc func(dagpb.String) dagpb.String
 
-func NewUnixFSDirMapIterator(itr PBLinkItr, transformName TransformNameFunc) ipld.MapIterator {
+func NewUnixFSDirMapIterator(itr pbLinkItr, transformName TransformNameFunc) ipld.MapIterator {
 	return &UnixFSDir__MapItr{itr, transformName}
 }
 
 // UnixFSDir__MapItr throught the links as if they were a map
 // Note: for now it does return links with no name, where the key is just String("")
 type UnixFSDir__MapItr struct {
-	_substrate    PBLinkItr
+	_substrate    pbLinkItr
 	transformName TransformNameFunc
 }
 
@@ -53,11 +53,11 @@ func (itr *UnixFSDir__MapItr) Done() bool {
 }
 
 type UnixFSDir__Itr struct {
-	_substrate    PBLinkItr
+	_substrate    pbLinkItr
 	transformName TransformNameFunc
 }
 
-func NewUnixFSDirIterator(itr PBLinkItr, transformName TransformNameFunc) *UnixFSDir__Itr {
+func NewUnixFSDirIterator(itr pbLinkItr, transformName TransformNameFunc) *UnixFSDir__Itr {
 	return &UnixFSDir__Itr{itr, transformName}
 }
 func (itr *UnixFSDir__Itr) Next() (k dagpb.String, v dagpb.Link) {

--- a/pathpbnode.go
+++ b/pathpbnode.go
@@ -49,7 +49,7 @@ func (n PathedPBNode) LookupBySegment(seg ipld.PathSegment) (ipld.Node, error) {
 }
 
 func (n PathedPBNode) MapIterator() ipld.MapIterator {
-	return iter.NewUnixFSDirMapIterator(n._substrate.Links.Iterator(), nil)
+	return iter.NewUnixFSDirMapIterator(&_PathedPBNode__ListItr{n._substrate.Links.Iterator()}, nil)
 }
 
 // ListIterator returns an iterator which yields key-value pairs
@@ -119,8 +119,7 @@ func (n PathedPBNode) Representation() ipld.Node {
 // Native map accessors
 
 func (n PathedPBNode) Iterator() *iter.UnixFSDir__Itr {
-
-	return iter.NewUnixFSDirIterator(n._substrate.Links.Iterator(), nil)
+	return iter.NewUnixFSDirIterator(&_PathedPBNode__ListItr{n._substrate.Links.Iterator()}, nil)
 }
 
 func (n PathedPBNode) Lookup(key dagpb.String) dagpb.Link {
@@ -140,4 +139,17 @@ func (n PathedPBNode) FieldData() dagpb.MaybeBytes {
 // Substrate returns the underlying PBNode -- note: only the substrate will encode successfully to protobuf if writing
 func (n PathedPBNode) Substrate() ipld.Node {
 	return n._substrate
+}
+
+type _PathedPBNode__ListItr struct {
+	_substrate *dagpb.PBLinks__Itr
+}
+
+func (itr *_PathedPBNode__ListItr) Next() (int64, dagpb.PBLink, error) {
+	idx, v := itr._substrate.Next()
+	return idx, v, nil
+}
+
+func (itr *_PathedPBNode__ListItr) Done() bool {
+	return itr._substrate.Done()
 }


### PR DESCRIPTION
When you try to iterate over a shard where you don't have access to all the blocks, because we don't propagate the actual error we get an overrun error, which doesn't tell you much. This change propagates the error so you have a chance at intuiting what's going on.

If you `car extract` the wikipedia partial CAR in https://github.com/ipld/go-car/pull/384 prior to this change you get an error:


```
2023/03/07 22:18:59 bafybeiaysi4s6lnjev27ln5icwm6tueaw2vdykrtjkwiphwekaywqhcjze: iterator overread
```

with this change you get:

```
2023/03/07 22:33:22 bafybeiaysi4s6lnjev27ln5icwm6tueaw2vdykrtjkwiphwekaywqhcjze: ipld: could not find bafybeichnleonsnrhdmykteijc2klanhwcrzoek4bzgdkx6amq3gwtj6uq
```

the first CID is the shard root, the second CID is the first one in the substrate that it tries to load for a complete iteration.