### PR TITLE
fix: do not read extra block if offset = at+childSize

### DIFF
--- a/file/large_file_test.go
+++ b/file/large_file_test.go
@@ -94,7 +94,6 @@ func TestLargeFileReaderReadsOnlyNecessaryBlocks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Log("Before Read", tracker.cids)
 	// Prepare tracker for read.
 	tracker.resetTracker()
 

--- a/file/shard.go
+++ b/file/shard.go
@@ -50,7 +50,7 @@ func (s *shardNodeReader) makeReader() (io.Reader, error) {
 		if err != nil {
 			return nil, err
 		}
-		if s.offset > at+childSize {
+		if s.offset >= at+childSize {
 			at += childSize
 			continue
 		}

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v1.7.0"
+  "version": "v1.7.1"
 }


### PR DESCRIPTION
Thanks to @aschmahmann for finding this bug. The issue is that if `offset == at+childSize`, we would be reading an unnecessary block.

Needed in the context of IPIP-402 (https://github.com/ipfs/boxo/pull/303). We were getting one unnecessary block. I added a test, which fails without the fix.