### PR TITLE
Provide list iterator interface

### DIFF
--- a/directory/basicdir.go
+++ b/directory/basicdir.go
@@ -70,7 +70,7 @@ func (n UnixFSBasicDir) MapIterator() ipld.MapIterator {
 // can be expected that itr.Next will be called node.Length times
 // before itr.Done becomes true.
 func (n UnixFSBasicDir) ListIterator() ipld.ListIterator {
-	return nil
+	return iter.NewUnixFSDirListIterator(&_UnixFSBasicDir__ListItr{n._substrate.Links.Iterator()}, nil)
 }
 
 // Length returns the length of a list, or the number of entries in a map,

--- a/hamt/shardeddir.go
+++ b/hamt/shardeddir.go
@@ -256,7 +256,14 @@ func (itr *_UnixFSShardedDir__ListItr) Done() bool {
 // can be expected that itr.Next will be called node.Length times
 // before itr.Done becomes true.
 func (n UnixFSHAMTShard) ListIterator() ipld.ListIterator {
-	return nil
+	maxPadLen := maxPadLength(n.data)
+	listItr := &_UnixFSShardedDir__ListItr{
+		_substrate: n.FieldLinks().Iterator(),
+		maxPadLen:  maxPadLen,
+		nd:         n,
+	}
+	st := stringTransformer{maxPadLen: maxPadLen}
+	return iter.NewUnixFSDirListIterator(listItr, st.transformNameNode)
 }
 
 // Length returns the length of a list, or the number of entries in a map,


### PR DESCRIPTION
# Goals

Allows a UnixFS dirs and HAMT dirs to be interated as a list. This works the same as the MapIterator interface but allows accessing the TSize property.

Note when iterating a HAMT, only leaf nodes are returned, and the Name field is shortened to not include the hamt prefix