### PR TITLE
feat: add entity matcher w/o preload, add matcher fn for consuming bytes

### DIFF
--- a/signalling_test.go
+++ b/signalling_test.go
@@ -22,6 +22,9 @@ var exploreAllJson = mustDagJson(selectorparse.CommonSelector_ExploreAllRecursiv
 // explore interpret-as (~), next (>), match (.), interpreted as unixfs-preload
 var matchUnixfsPreloadJson = `{"~":{">":{".":{}},"as":"unixfs-preload"}}`
 
+// explore interpret-as (~), next (>), union (|) of match (.) and explore recursive (R) edge (@) with a depth of 1, interpreted as unixfs
+var matchUnixfsEntityJson = `{"~":{">":{"|":[{".":{}},{"R":{":>":{"a":{">":{"@":{}}}},"l":{"depth":1}}}]},"as":"unixfs"}}`
+
 // match interpret-as (~), next (>), match (.), interpreted as unixfs
 var matchUnixfsJson = `{"~":{">":{".":{}},"as":"unixfs"}}`
 
@@ -93,10 +96,16 @@ func TestUnixFSPathSelectorBuilder(t *testing.T) {
 			expextedSelector: exploreAllJson,
 		},
 		{
-			name:             "empty path shallow",
+			name:             "empty path shallow (preload)",
 			path:             "",
 			target:           unixfsnode.MatchUnixFSPreloadSelector,
 			expextedSelector: matchUnixfsPreloadJson,
+		},
+		{
+			name:             "empty path shallow (entity)",
+			path:             "",
+			target:           unixfsnode.MatchUnixFSEntitySelector,
+			expextedSelector: matchUnixfsEntityJson,
 		},
 		{
 			name:             "single field",
@@ -112,10 +121,16 @@ func TestUnixFSPathSelectorBuilder(t *testing.T) {
 			matchPath:        true,
 		},
 		{
-			name:             "single field shallow",
+			name:             "single field shallow (preload)",
 			path:             "/foo",
 			expextedSelector: jsonFields(matchUnixfsPreloadJson, "foo"),
 			target:           unixfsnode.MatchUnixFSPreloadSelector,
+		},
+		{
+			name:             "single field shallow (entity)",
+			path:             "/foo",
+			expextedSelector: jsonFields(matchUnixfsEntityJson, "foo"),
+			target:           unixfsnode.MatchUnixFSEntitySelector,
 		},
 		{
 			name:             "multiple fields",


### PR DESCRIPTION
~~Draft, WIP, for experimenting with~~ https://github.com/filecoin-project/lassie/pull/306

* Added `MatchUnixFSEntitySelector` as a replacement for `MatchUnixFSPreloadSelector` that doesn't use unixfs-preload. Added a possible deprecation notice to `MatchUnixFSPreloadSelector`.
* Added `BytesConsumingMatcher` as a matcher function for `traversal.WalkMatching` that will slurp bytes for you upon match, designed for use with the `Match*` selectors in here.