### PR TITLE
fix: proper tsize encoding in sharded files

### DIFF
--- a/data/builder/dir_test.go
+++ b/data/builder/dir_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/ipfs/go-cid"
-	u "github.com/ipfs/go-ipfs-util"
+	ipfsutil "github.com/ipfs/go-ipfs-util"
 	"github.com/ipfs/go-unixfsnode"
 	dagpb "github.com/ipld/go-codec-dagpb"
 	"github.com/ipld/go-ipld-prime"
@@ -43,7 +43,7 @@ func TestBuildUnixFSFileWrappedInDirectory_Reference(t *testing.T) {
 	for _, tc := range referenceTestCases {
 		t.Run(strconv.Itoa(tc.size), func(t *testing.T) {
 			buf := make([]byte, tc.size)
-			u.NewSeededRand(0xdeadbeef).Read(buf)
+			ipfsutil.NewSeededRand(0xdeadbeef).Read(buf)
 			r := bytes.NewReader(buf)
 
 			ls := cidlink.DefaultLinkSystem()

--- a/data/builder/file.go
+++ b/data/builder/file.go
@@ -166,11 +166,11 @@ func fileTreeRecursive(depth int, children []ipld.Link, childLen []uint64, src c
 	}
 	pbn := dpbb.Build()
 
-	link, _, err := sizedStore(ls, fileLinkProto, pbn)
+	link, sz, err := sizedStore(ls, fileLinkProto, pbn)
 	if err != nil {
 		return nil, 0, err
 	}
-	return link, totalSize, nil
+	return link, totalSize + sz, nil
 }
 
 // BuildUnixFSDirectoryEntry creates the link to a file or directory as it appears within a unixfs directory.

--- a/data/builder/file_test.go
+++ b/data/builder/file_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/ipfs/go-cid"
-	u "github.com/ipfs/go-ipfs-util"
+	ipfsutil "github.com/ipfs/go-ipfs-util"
 	"github.com/ipfs/go-unixfsnode/file"
 	dagpb "github.com/ipld/go-codec-dagpb"
 	"github.com/ipld/go-ipld-prime"
@@ -50,7 +50,7 @@ func TestBuildUnixFSFile_Reference(t *testing.T) {
 	for _, tc := range referenceTestCases {
 		t.Run(strconv.Itoa(tc.size), func(t *testing.T) {
 			buf := make([]byte, tc.size)
-			u.NewSeededRand(0xdeadbeef).Read(buf)
+			ipfsutil.NewSeededRand(0xdeadbeef).Read(buf)
 			r := bytes.NewReader(buf)
 
 			ls := cidlink.DefaultLinkSystem()
@@ -74,7 +74,7 @@ func TestBuildUnixFSFile_Reference(t *testing.T) {
 
 func TestUnixFSFileRoundtrip(t *testing.T) {
 	buf := make([]byte, 10*1024*1024)
-	u.NewSeededRand(0xdeadbeef).Read(buf)
+	ipfsutil.NewSeededRand(0xdeadbeef).Read(buf)
 	r := bytes.NewReader(buf)
 
 	ls := cidlink.DefaultLinkSystem()

--- a/test/partial_file_access_test.go
+++ b/test/partial_file_access_test.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"testing"
 
-	u "github.com/ipfs/go-ipfs-util"
+	ipfsutil "github.com/ipfs/go-ipfs-util"
 	"github.com/ipfs/go-unixfsnode/data/builder"
 	"github.com/ipfs/go-unixfsnode/file"
 	dagpb "github.com/ipld/go-codec-dagpb"
@@ -21,7 +21,7 @@ import (
 
 func TestPartialFileAccess(t *testing.T) {
 	buf := make([]byte, 10*1024*1024)
-	u.NewSeededRand(0xdeadbeef).Read(buf)
+	ipfsutil.NewSeededRand(0xdeadbeef).Read(buf)
 	r := bytes.NewReader(buf)
 
 	ls := cidlink.DefaultLinkSystem()


### PR DESCRIPTION
Extracted from https://github.com/ipfs/go-unixfsnode/pull/53, but fixed up to actually work properly - it turns out that passing on `sz` isn't quite right because of the need to care about the file byte sizes, so we need to track bot tsize and bytesizes.

Added some fixtures with reference CIDs so we can lock this behaviour down, references generated using Kubo; one of them was already in here (bafybeieyxejezqto5xwcxtvh5tskowwxrn3hmbk3hcgredji3g7abtnfkq) and it's unchanged, but expanded a little.