### PR TITLE
files returned from unixfsnode should be traversable to their substrate

### DIFF
--- a/file/file.go
+++ b/file/file.go
@@ -5,6 +5,8 @@ import (
 	"io"
 
 	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/adl"
+	"github.com/ipld/go-ipld-prime/datamodel"
 )
 
 // NewUnixFSFile attempts to construct an ipld node from the base protobuf node representing the
@@ -54,7 +56,7 @@ func NewUnixFSFileWithPreload(ctx context.Context, substrate ipld.Node, lsys *ip
 
 // A LargeBytesNode is an ipld.Node that can be streamed over. It is guaranteed to have a Bytes type.
 type LargeBytesNode interface {
-	ipld.Node
+	adl.ADL
 	AsLargeBytes() (io.ReadSeeker, error)
 }
 
@@ -64,6 +66,10 @@ type singleNodeFile struct {
 
 func (f *singleNodeFile) AsLargeBytes() (io.ReadSeeker, error) {
 	return &singleNodeReader{f, 0}, nil
+}
+
+func (f *singleNodeFile) Substrate() datamodel.Node {
+	return f.Node
 }
 
 type singleNodeReader struct {

--- a/file/shard.go
+++ b/file/shard.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ipfs/go-unixfsnode/data"
 	dagpb "github.com/ipld/go-codec-dagpb"
 	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/adl"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipld/go-ipld-prime/node/basicnode"
 	"github.com/multiformats/go-multicodec"
@@ -24,7 +25,7 @@ type shardNodeFile struct {
 	unpackLk sync.Once
 }
 
-var _ ipld.Node = (*shardNodeFile)(nil)
+var _ adl.ADL = (*shardNodeFile)(nil)
 
 type shardNodeReader struct {
 	*shardNodeFile
@@ -231,6 +232,10 @@ func (s *shardNodeFile) lengthFromLinks() int64 {
 
 func (s *shardNodeFile) AsLargeBytes() (io.ReadSeeker, error) {
 	return &shardNodeReader{s, nil, 0, 0}, nil
+}
+
+func (s *shardNodeFile) Substrate() ipld.Node {
+	return s.substrate
 }
 
 func protoFor(link ipld.Link) ipld.NodePrototype {


### PR DESCRIPTION
This is looking at the fuse issue raised in https://github.com/ipfs/kubo/issues/9044#issuecomment-1693326391

What seems to occur is that the node we get [when resolving a file](https://github.com/ipfs/kubo/blob/16859b3c70ee28905deb38a3c6e38420b93f3609/fuse/readonly/readonly_unix.go#L93-L99) returns a unixfsnode File.

The `ProtoNodeConverter` only works on a direct [PBNode](https://github.com/ipfs/boxo/blob/79159c31ef43f8eeb129f1177a8d7ed665122f54/ipld/merkledag/node.go#L556) so in the case that the response has been ADL'd into a unixfs File, we need to give it the substrate rather than the file

separately, this logic is brittle / unable to handle the `io.ReadSeeker` / large bytes node efficiency possible with unixfsnode and should get a larger refactor to support that.

However, in the mean time, this indicates that these files do comply with the ADL interface and so we can get the underlying substrate for use in fuse rather than the full file ipld object.