### PR TITLE
v1.8.0 bump

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v1.7.4"
+  "version": "v1.8.0"
 }


### PR DESCRIPTION
Justification for the semver-minor bump:
* #67
* Go 1.20 update (strictly speaking this should be a semver-major but I don't think that's common practice since semver-major bumps are so painful in Go)